### PR TITLE
add launch on binder link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ We include the following folders and files in this repository:
 
 `CVI_data_dictionary.xlsx` is a Microsoft Excel Worksheet containing a data dictionary describing the variables pertaining to the CVI. 
 
-## How to run the code? 
+## How to run the code? [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/CentroPR/child-vulnerability-index/85dbe77?labpath=code%2F01_data_pull_from_Census_API.ipynb)
 
 The code contained in the folder `code/` consists of five jupyter notebook files (`.ipynb`) containing code written in python. 
 


### PR DESCRIPTION
Adds a "Launch On Binder" link to facilitate reproducibility, this will permit users to try this code directly on the cloud, without having to install a conda environment locally.
<img width="1038" alt="image" src="https://github.com/CentroPR/child-vulnerability-index/assets/6123372/09ed3838-ccfa-440a-b2d9-b9416453efc4">

Current placement is a suggestion, can be moved elsewhere.